### PR TITLE
Runner timeout update

### DIFF
--- a/docker/cactus-runner/Dockerfile
+++ b/docker/cactus-runner/Dockerfile
@@ -33,5 +33,5 @@ ENV APP_HOST='0.0.0.0'
 ENV APP_PORT='8080'
 
 # run app
-CMD ["sh", "-c", "exec gunicorn cactus_runner.app.main:app --bind ${APP_HOST}:${APP_PORT} --worker-class aiohttp.GunicornWebWorker"]
+CMD ["sh", "-c", "exec gunicorn cactus_runner.app.main:app --bind ${APP_HOST}:${APP_PORT} --worker-class aiohttp.GunicornWebWorker --timeout 60"]
 

--- a/k8s-cluster/deploy-template/app-setup/cactus-teststack-v12.yaml
+++ b/k8s-cluster/deploy-template/app-setup/cactus-teststack-v12.yaml
@@ -47,6 +47,13 @@ spec:
             value: admin
           - name: ENVOY_ADMIN_BASICAUTH_PASSWORD
             value: password
+          # Optional: cap on-disk request/response pairs retained during a test (default 5000).
+          # Also controls max request_history entries serialized into the ZIP.
+          # - name: MAX_REQUEST_PAIRS
+          #   value: "5000"
+          # Optional: max bytes copied from each log file into the ZIP archive, tail of file (default 32 MB).
+          # - name: MAX_LOG_FILE_BYTES
+          #   value: "32000000"
         readinessProbe:
           httpGet:
             path: /health

--- a/k8s-cluster/deploy-template/app-setup/cactus-teststack-v13-beta-storage.yaml
+++ b/k8s-cluster/deploy-template/app-setup/cactus-teststack-v13-beta-storage.yaml
@@ -47,6 +47,13 @@ spec:
             value: admin
           - name: ENVOY_ADMIN_BASICAUTH_PASSWORD
             value: password
+          # Optional: cap on-disk request/response pairs retained during a test (default 5000).
+          # Also controls max request_history entries serialized into the ZIP.
+          # - name: MAX_REQUEST_PAIRS
+          #   value: "5000"
+          # Optional: max bytes copied from each log file into the ZIP archive, tail of file (default 32 MB).
+          # - name: MAX_LOG_FILE_BYTES
+          #   value: "32000000"
         readinessProbe:
           httpGet:
             path: /health


### PR DESCRIPTION
This bug is mostly handled by upcoming changes to runner (memory issue plus 30s timeout problems). These two commented out env variables are added for future visbility, and 60s feels more reasonable than the default 30s worker timeout.