### PR TITLE
uv

### DIFF
--- a/docker/cactus-client-notifications/Dockerfile
+++ b/docker/cactus-client-notifications/Dockerfile
@@ -1,27 +1,41 @@
+# UV Docker best practices: https://docs.astral.sh/uv/guides/integration/docker/
 # BUILD stage
-FROM python:3.12-slim AS build
+FROM python:3.12-slim-bookworm AS builder
+COPY --from=ghcr.io/astral-sh/uv:0.11.16 /uv /bin/uv
+
 ARG CACTUS_CLIENT_NOTIFICATIONS_VERSION
 ARG GITHUB_ORG=bsgip
 
-RUN apt-get update; apt-get install -y git openssh-client
+# pre-compile .pyc at build time for faster startup; copy instead of hardlink (cache mount
+# requirement); strip dev deps; use the image's Python rather than downloading a new one
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_NO_DEV=1 \
+    UV_PYTHON_DOWNLOADS=0
 
-# Setup the git config to use https
-RUN git config --global url."https://git@github.com/".insteadOf "ssh://git@github.com/"
+RUN apt-get update && apt-get install --no-install-recommends -y git && rm -rf /var/lib/apt/lists/*
 
-# Install app / dependencies
-RUN pip install --no-cache-dir "cactus-client-notifications[server] @ git+ssh://git@github.com/${GITHUB_ORG}/cactus-client-notifications.git@${CACTUS_CLIENT_NOTIFICATIONS_VERSION}" gunicorn
+# Clone so uv can read pyproject.toml + uv.lock for a fully locked install.
+# Previously pip install git+... was used but couldn't leverage the lock file.
+WORKDIR /app
+RUN git clone --depth 1 --branch ${CACTUS_CLIENT_NOTIFICATIONS_VERSION} \
+    https://github.com/${GITHUB_ORG}/cactus-client-notifications.git . || \
+    (git clone https://github.com/${GITHUB_ORG}/cactus-client-notifications.git . && \
+     git checkout ${CACTUS_CLIENT_NOTIFICATIONS_VERSION})
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked --no-editable --extra server && \
+    uv pip install gunicorn
 
 # RUN stage
-FROM  python:3.12-slim
-
+FROM python:3.12-slim-bookworm
 
 WORKDIR /app
 
-# Copy env
-COPY --from=build --chown=appuser:appuser /usr/local/lib/  /usr/local/lib/
-COPY --from=build --chown=appuser:appuser /usr/local/bin/  /usr/local/bin/
+COPY --from=builder /app/.venv /app/.venv
 
 # conf
+ENV PATH="/app/.venv/bin:$PATH"
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 ENV APP_HOST='0.0.0.0'
@@ -29,4 +43,3 @@ ENV APP_PORT='8080'
 
 # run app
 CMD ["sh", "-c", "exec gunicorn cactus_client_notifications.server.main:app --bind ${APP_HOST}:${APP_PORT} --worker-class aiohttp.GunicornWebWorker"]
-

--- a/docker/cactus-client-notifications/Dockerfile
+++ b/docker/cactus-client-notifications/Dockerfile
@@ -25,7 +25,7 @@ RUN git clone --depth 1 --branch ${CACTUS_CLIENT_NOTIFICATIONS_VERSION} \
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked --no-editable --extra server && \
-    uv pip install gunicorn
+    uv pip install "gunicorn==26.0.0"
 
 # RUN stage
 FROM python:3.12-slim-bookworm

--- a/docker/cactus-orchestrator/Dockerfile
+++ b/docker/cactus-orchestrator/Dockerfile
@@ -25,7 +25,7 @@ RUN git clone --depth 1 --branch ${CACTUS_ORCHESTRATOR_VERSION} \
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked --no-editable && \
-    uv pip install uvicorn
+    uv pip install "uvicorn==0.48.0"
 
 # RUN stage
 FROM python:3.12-slim-bookworm
@@ -34,7 +34,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y postgresql && r
 
 # entrypoint
 COPY entrypoint.sh /entrypoint.sh
-RUN chmod o+x /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 RUN useradd -ms /bin/bash appuser
 

--- a/docker/cactus-orchestrator/Dockerfile
+++ b/docker/cactus-orchestrator/Dockerfile
@@ -1,33 +1,49 @@
+# UV Docker best practices: https://docs.astral.sh/uv/guides/integration/docker/
 # BUILD stage
-FROM python:3.12-slim AS build
+FROM python:3.12-slim-bookworm AS builder
+COPY --from=ghcr.io/astral-sh/uv:0.11.16 /uv /bin/uv
+
 ARG CACTUS_ORCHESTRATOR_VERSION
 ARG GITHUB_ORG=bsgip
 
-RUN apt update && apt install --no-install-recommends -y git openssh-client && rm -rf /var/lib/apt/lists/*
+# pre-compile .pyc at build time for faster startup; copy instead of hardlink (cache mount
+# requirement); strip dev deps; use the image's Python rather than downloading a new one
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_NO_DEV=1 \
+    UV_PYTHON_DOWNLOADS=0
 
-# Setup the git config to use https
-RUN git config --global url."https://git@github.com/".insteadOf "ssh://git@github.com/"
+RUN apt-get update && apt-get install --no-install-recommends -y git && rm -rf /var/lib/apt/lists/*
 
-# Install deps
-RUN pip install --no-cache-dir uvicorn git+ssh://git@github.com/${GITHUB_ORG}/cactus-orchestrator.git@${CACTUS_ORCHESTRATOR_VERSION}
+# Clone so uv can read pyproject.toml + uv.lock for a fully locked install.
+# Previously pip install git+... was used but couldn't leverage the lock file.
+WORKDIR /app
+RUN git clone --depth 1 --branch ${CACTUS_ORCHESTRATOR_VERSION} \
+    https://github.com/${GITHUB_ORG}/cactus-orchestrator.git . || \
+    (git clone https://github.com/${GITHUB_ORG}/cactus-orchestrator.git . && \
+     git checkout ${CACTUS_ORCHESTRATOR_VERSION})
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked --no-editable && \
+    uv pip install uvicorn
 
 # RUN stage
-FROM python:3.12-slim
+FROM python:3.12-slim-bookworm
 
-RUN apt update && apt install --no-install-recommends -y postgresql && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install --no-install-recommends -y postgresql && rm -rf /var/lib/apt/lists/*
 
 # entrypoint
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod o+x /entrypoint.sh
 
 RUN useradd -ms /bin/bash appuser
+
+COPY --from=builder --chown=appuser:appuser /app/.venv /app/.venv
+
 USER appuser
 
-# Copy env
-COPY --from=build --chown=appuser:appuser /usr/local/lib/ /usr/local/lib/
-COPY --from=build --chown=appuser:appuser /usr/local/bin/ /usr/local/bin/
-
 # conf
+ENV PATH="/app/.venv/bin:$PATH"
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 

--- a/docker/cactus-runner/Dockerfile
+++ b/docker/cactus-runner/Dockerfile
@@ -25,7 +25,7 @@ RUN git clone --depth 1 --branch ${CACTUS_RUNNER_VERSION} \
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked --no-editable && \
-    uv pip install gunicorn
+    uv pip install "gunicorn==26.0.0"
 
 # RUN stage
 FROM python:3.12-slim-bookworm

--- a/docker/cactus-runner/Dockerfile
+++ b/docker/cactus-runner/Dockerfile
@@ -1,33 +1,47 @@
+# UV Docker best practices: https://docs.astral.sh/uv/guides/integration/docker/
 # BUILD stage
-FROM python:3.12-slim AS build
+FROM python:3.12-slim-bookworm AS builder
+COPY --from=ghcr.io/astral-sh/uv:0.11.16 /uv /bin/uv
+
 ARG CACTUS_RUNNER_VERSION
 ARG GITHUB_ORG=bsgip
 
-RUN apt-get update; apt-get install -y git openssh-client
+# pre-compile .pyc at build time for faster startup; copy instead of hardlink (cache mount
+# requirement); strip dev deps; use the image's Python rather than downloading a new one
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_NO_DEV=1 \
+    UV_PYTHON_DOWNLOADS=0
 
-# Setup the git config to use https
-RUN git config --global url."https://git@github.com/".insteadOf "ssh://git@github.com/"
+RUN apt-get update && apt-get install --no-install-recommends -y git && rm -rf /var/lib/apt/lists/*
 
-# Install app / dependencies
-RUN pip install --no-cache-dir "git+ssh://git@github.com/${GITHUB_ORG}/cactus-runner.git@${CACTUS_RUNNER_VERSION}" gunicorn
+# Clone so uv can read pyproject.toml + uv.lock for a fully locked install.
+# Previously pip install git+... was used but couldn't leverage the lock file.
+WORKDIR /app
+RUN git clone --depth 1 --branch ${CACTUS_RUNNER_VERSION} \
+    https://github.com/${GITHUB_ORG}/cactus-runner.git . || \
+    (git clone https://github.com/${GITHUB_ORG}/cactus-runner.git . && \
+     git checkout ${CACTUS_RUNNER_VERSION})
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked --no-editable && \
+    uv pip install gunicorn
 
 # RUN stage
-FROM  python:3.12-slim
+FROM python:3.12-slim-bookworm
 
 # This postgresql-client version shouldn't be "behind" the postgres version in the k8s pod
 # eg: If the pod is running postgres:15, don't install postgresql-client-14
-RUN apt update && apt install --no-install-recommends -y postgresql-client && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install --no-install-recommends -y postgresql-client && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
-RUN mkdir -p config/logging
-RUN mkdir /shared
+RUN mkdir -p config/logging && mkdir /shared
 COPY ./logconf.json /app/config/logging/config.json
 
-# Copy env
-COPY --from=build --chown=appuser:appuser /usr/local/lib/  /usr/local/lib/
-COPY --from=build --chown=appuser:appuser /usr/local/bin/  /usr/local/bin/
+COPY --from=builder /app/.venv /app/.venv
 
 # conf
+ENV PATH="/app/.venv/bin:$PATH"
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 ENV APP_HOST='0.0.0.0'
@@ -35,4 +49,3 @@ ENV APP_PORT='8080'
 
 # run app
 CMD ["sh", "-c", "exec gunicorn cactus_runner.app.main:app --bind ${APP_HOST}:${APP_PORT} --worker-class aiohttp.GunicornWebWorker --timeout 60"]
-

--- a/docker/cactus-teststack-init/Dockerfile
+++ b/docker/cactus-teststack-init/Dockerfile
@@ -1,29 +1,44 @@
+# UV Docker best practices: https://docs.astral.sh/uv/guides/integration/docker/
 # (1) Make database migration stage
-# We need a DB migration file - easiest way to
-FROM python:3.11-slim-bookworm AS make-migration
+FROM python:3.11-slim-bookworm AS builder
+COPY --from=ghcr.io/astral-sh/uv:0.11.16 /uv /bin/uv
 
 ARG ENVOY_VERSION
 ARG GITHUB_ORG=bsgip
 
+# copy instead of hardlink (cache mount requirement); strip dev deps;
+# use the image's Python rather than downloading a new one
+# UV_COMPILE_BYTECODE intentionally omitted - venv is discarded after generating migrate.sql
+ENV UV_LINK_MODE=copy \
+    UV_NO_DEV=1 \
+    UV_PYTHON_DOWNLOADS=0
+
+RUN apt-get update && apt-get install --no-install-recommends -y git && rm -rf /var/lib/apt/lists/*
+
+# Clone so uv can read pyproject.toml + uv.lock for a fully locked install.
+# Previously pip install git+... was used but couldn't leverage the lock file.
 WORKDIR /app
+RUN git clone --depth 1 --branch ${ENVOY_VERSION} \
+    https://github.com/${GITHUB_ORG}/envoy.git . || \
+    (git clone https://github.com/${GITHUB_ORG}/envoy.git . && \
+     git checkout ${ENVOY_VERSION})
 
-# Deps
-RUN apt update && apt install --no-install-recommends -y git
-RUN pip install --no-cache-dir -e git+https://git@github.com/${GITHUB_ORG}/envoy.git@${ENVOY_VERSION}#egg=envoy
-RUN pip install --no-cache-dir alembic
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked --no-editable
 
-WORKDIR /app/src/envoy/src/envoy/server
+ENV PATH="/app/.venv/bin:$PATH"
 
+WORKDIR /app/src/envoy/server
 ENV DATABASE_URL="postgresql://abc:abc@abc/abc"
 RUN alembic upgrade head --sql > /app/migrate.sql
 
 # (2) Final stage
-FROM alpine:latest
+FROM alpine:3.23
 
 RUN apk add --no-cache inotify-tools bash postgresql-client
 
 # Envoy migrations sql, tail it for current alembic revision
-COPY --from=make-migration /app/migrate.sql /migrate.sql
+COPY --from=builder /app/migrate.sql /migrate.sql
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/docker/cactus-ui/Dockerfile
+++ b/docker/cactus-ui/Dockerfile
@@ -25,7 +25,7 @@ RUN git clone --depth 1 --branch ${CACTUS_UI_VERSION} \
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked --no-editable && \
-    uv pip install uvicorn
+    uv pip install "uvicorn==0.48.0"
 
 # Copy static overrides into the installed package directory
 COPY static /tmp/static

--- a/docker/cactus-ui/Dockerfile
+++ b/docker/cactus-ui/Dockerfile
@@ -1,41 +1,51 @@
+# UV Docker best practices: https://docs.astral.sh/uv/guides/integration/docker/
 # BUILD stage
-FROM python:3.12-slim AS build
+FROM python:3.12-slim-bookworm AS builder
+COPY --from=ghcr.io/astral-sh/uv:0.11.16 /uv /bin/uv
+
 ARG CACTUS_UI_VERSION
 ARG GITHUB_ORG=bsgip
 
-RUN apt update && apt install --no-install-recommends -y git openssh-client && rm -rf /var/lib/apt/lists/*
+# pre-compile .pyc at build time for faster startup; copy instead of hardlink (cache mount
+# requirement); strip dev deps; use the image's Python rather than downloading a new one
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_NO_DEV=1 \
+    UV_PYTHON_DOWNLOADS=0
 
-# Setup the git config to use https
-RUN git config --global url."https://git@github.com/".insteadOf "ssh://git@github.com/"
+RUN apt-get update && apt-get install --no-install-recommends -y git && rm -rf /var/lib/apt/lists/*
 
-# Install deps
-RUN pip install --no-cache-dir uvicorn git+ssh://git@github.com/${GITHUB_ORG}/cactus-ui.git@${CACTUS_UI_VERSION} && pip uninstall -y cactus-ui
-RUN mkdir /app
-RUN pip install --no-cache-dir --no-deps --target /app/ git+ssh://git@github.com/${GITHUB_ORG}/cactus-ui.git@${CACTUS_UI_VERSION}
+# Clone so uv can read pyproject.toml + uv.lock for a fully locked install.
+# Previously pip install git+... was used but couldn't leverage the lock file.
+WORKDIR /app
+RUN git clone --depth 1 --branch ${CACTUS_UI_VERSION} \
+    https://github.com/${GITHUB_ORG}/cactus-ui.git . || \
+    (git clone https://github.com/${GITHUB_ORG}/cactus-ui.git . && \
+     git checkout ${CACTUS_UI_VERSION})
 
-# Copy static dependencies (seperate dir) - we will merge them with what was installed in the python build
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked --no-editable && \
+    uv pip install uvicorn
+
+# Copy static overrides into the installed package directory
 COPY static /tmp/static
-RUN cp -rn /tmp/static/* /app/cactus_ui/static/
-
-
-
+RUN cp -rn /tmp/static/* /app/.venv/lib/python3.12/site-packages/cactus_ui/static/
 
 # RUN stage
-FROM python:3.12-slim
+FROM python:3.12-slim-bookworm
 
 RUN useradd -ms /bin/bash appuser
+
+COPY --from=builder --chown=appuser:appuser /app/.venv /app/.venv
+
 USER appuser
 WORKDIR /home/appuser/app/
 
-# Copy env
-COPY --from=build --chown=appuser:appuser /app/ /home/appuser/app/
-COPY --from=build --chown=appuser:appuser /usr/local/lib/  /usr/local/lib/
-COPY --from=build --chown=appuser:appuser /usr/local/bin/  /usr/local/bin/
-
 # conf
+ENV PATH="/app/.venv/bin:$PATH"
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
-COPY ./logconf.json /home/appuser/app/logconf.json
+COPY --chown=appuser:appuser ./logconf.json /home/appuser/app/logconf.json
 
 # Entrypoint
 CMD ["uvicorn", "--host", "0.0.0.0", "--port", "8080", "--workers", "1", "--interface", "wsgi", "cactus_ui.server:app"]

--- a/docker/envoy/Dockerfile
+++ b/docker/envoy/Dockerfile
@@ -1,12 +1,40 @@
-FROM python:3.12-slim-bookworm
+# UV Docker best practices: https://docs.astral.sh/uv/guides/integration/docker/
+# BUILD stage
+FROM python:3.12-slim-bookworm AS builder
+COPY --from=ghcr.io/astral-sh/uv:0.11.16 /uv /bin/uv
+
 ARG ENVOY_VERSION
 ARG GITHUB_ORG=bsgip
 
+# pre-compile .pyc at build time for faster startup; copy instead of hardlink (cache mount
+# requirement); strip dev deps; use the image's Python rather than downloading a new one
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_NO_DEV=1 \
+    UV_PYTHON_DOWNLOADS=0
+
+RUN apt-get update && apt-get install --no-install-recommends -y git && rm -rf /var/lib/apt/lists/*
+
+# Clone so uv can read pyproject.toml + uv.lock for a fully locked install.
+# Previously pip install git+... was used but couldn't leverage the lock file.
+WORKDIR /app
+RUN git clone --depth 1 --branch ${ENVOY_VERSION} \
+    https://github.com/${GITHUB_ORG}/envoy.git . || \
+    (git clone https://github.com/${GITHUB_ORG}/envoy.git . && \
+     git checkout ${ENVOY_VERSION})
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked --no-editable && \
+    uv pip install uvicorn python-json-logger
+
+# RUN stage
+FROM python:3.12-slim-bookworm
+
 WORKDIR /app
 
-# Deps
-RUN apt update && apt install --no-install-recommends -y netcat-traditional git && rm -rf /var/lib/apt/lists/*
-RUN pip install --no-cache-dir git+https://git@github.com/${GITHUB_ORG}/envoy.git@${ENVOY_VERSION}#egg=envoy python-json-logger uvicorn
+RUN apt-get update && apt-get install --no-install-recommends -y netcat-traditional && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/.venv /app/.venv
 
 # logging config
 COPY logconf.admin.json ./logconf.admin.json
@@ -15,6 +43,7 @@ COPY logconf.server.json ./logconf.server.json
 RUN mkdir /shared
 
 # configurables
+ENV PATH="/app/.venv/bin:$PATH"
 ENV APP_MODULE="envoy.server.main:app"
 ENV WORKERS=1
 ENV LOG_CONFIG=logconf.server.json

--- a/docker/envoy/Dockerfile
+++ b/docker/envoy/Dockerfile
@@ -25,7 +25,7 @@ RUN git clone --depth 1 --branch ${ENVOY_VERSION} \
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked --no-editable && \
-    uv pip install uvicorn python-json-logger
+    uv pip install "uvicorn==0.48.0" "python-json-logger==4.1.0"
 
 # RUN stage
 FROM python:3.12-slim-bookworm


### PR DESCRIPTION
Move from pip to uv installs. mostly pulled from uv best practise docs and example.

- Replaces pip install git+ssh://... with git clone + uv sync --locked  (allows locking to the actual lock files from uv)
- venv at /app/.venv (recommended in uv docs), cleaner separation between build and runtime stages
- Envoy was previously single-stage, now multi should be smaller
- gunicorn/uvicorn/python-json-logger pinned explicitly. Deployment packages needed but not shown in the project toml/uv.lock files
- git clone fallback --depth 1 --branch $VERSION is used for tags/branches; the fallback to a full clone + git checkout handles commit SHAs (in case we want test deployments of non-main branches).
- alpine:latest pin alpine:3.23 in teststack-init.
- UV_PYTHON_DOWNLOADS=0 throughout forces uv to use the image's bundled Python.